### PR TITLE
ADD: Abstract for AMS Python talk

### DIFF
--- a/abstracts_presentations/ams_am_2017/abstract.rst
+++ b/abstracts_presentations/ams_am_2017/abstract.rst
@@ -1,0 +1,24 @@
+Building a roadmap for a mid-sized community software project: Perspectives from Py-ART
+=======================================================================================
+*Scott Collis, Jonathan Helmus and Cory Weber*
+
+The Python ARM Radar Toolkit (Py-ART, [1]) is an architecture for interacting
+with and extracting insight from weather radar data. While it is difficult to
+track total usage we estimate Py-ART has over a hundred active users with
+thousands of downloads from GitHub, pip and Conda installs. With fifteen
+developers and a very diverse funding background, led by the Department of
+Energy's ARM program, it is important to have a vision for how development on
+the package will proceed over the next five years. The codebase must serve the
+needs of ARM stakeholders as well as the needs of the wider community to ensure
+broad uptake and longevity. This presentation will report the results of the
+Py-ART roadmap survey and outline the five year roadmap for development
+prioritization. The roadmap prioritizes both directly funded development and
+the support for implementation of unsolicited pull requests to the Py-ART
+package.   
+
+
+[1] Helmus, J.J. & Collis, S.M., (2016). The Python ARM Radar Toolkit (Py-ART), 
+a Library for Working with Weather Radar Data in the Python Programming 
+Language. Journal of Open Research Software. 4(1), p.e25.
+DOI: http://doi.org/10.5334/jors.119
+


### PR DESCRIPTION
An abstract for the 2017 Python Symposium at the AMS Annual meeting has been
added. It is expected the roadmap will be complete at this time (January) and
this will give us a chance to showcase the procedure we went through
